### PR TITLE
Add support for "other" item types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const TEXT_REGEX = /^text\s+(.*)/;
 export const GLOW_REGEX = /^glow\s+(.*)/;
 export const LABEL_REGEX = /^label\s+(.*)/;
 export const OPTION_REGEX = /^option\s+(.*)/;
+export const OTHER_REGEX = /^other\s+(.*)/;
 export const HEX_REGEX = /^(-?\d\d)(-?\d\d)(\d\d)?\s+(.*)/;
 export const HEX_LABEL_REGEX = /["]([^"]+)["]\s*(\d+)?/;
 export const SPLINE_REGEX =
@@ -21,6 +22,7 @@ export interface SVGElement {
     createSvg(tag: string, options?: any): SVGElement;
     innerHTML: string;
     textContent: string;
+    insertAdjacentHTML(position: "beforebegin" | "afterbegin" | "beforeend" | "afterend", text: string) : void;
 }
 
 export type NamespaceFunction = {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9,6 +9,7 @@ import {
     LABEL_REGEX,
     HEX_REGEX,
     HEX_LABEL_REGEX,
+    OTHER_REGEX,
     SPLINE_REGEX,
     SPLINE_ELEMENT_SPLIT_REGEX,
     SPLINE_POINT_REGEX,
@@ -32,6 +33,7 @@ export class TextMapperParser {
     defs: string[]; // ' => sub { [] };
     path: any; // ' => sub { {} };
     splines: Spline[]; // ' => sub { [] };
+    others: string[]; // ' => sub { {} };
     pathAttributes: any; // ' => sub { {} };
     textAttributes: any;
     glowAttributes: any;
@@ -56,6 +58,7 @@ export class TextMapperParser {
         this.textAttributes = "";
         this.glowAttributes = "";
         this.labelAttributes = "";
+        this.others = [];
     }
 
     /**
@@ -133,6 +136,9 @@ export class TextMapperParser {
             } else if (LABEL_REGEX.test(line)) {
                 const match = line.match(LABEL_REGEX);
                 this.labelAttributes = this.parseAttributes(match[1]);
+            } else if (OTHER_REGEX.test(line)) {
+                const match = line.match(OTHER_REGEX)[0];
+                this.others.push(match);
             }
         }
     }
@@ -446,6 +452,15 @@ export class TextMapperParser {
         }
     }
 
+    svgOthers(svgEl: SVGElement): void {
+        const othersEl = svgEl.createSvg("g", {
+            attr: { id: this.namespace("others") },
+        });
+        for (const other of this.others) {
+            othersEl.insertAdjacentHTML("beforeend", other);
+        }
+    }
+
     svg(el: HTMLElement) {
         const svgEl = this.svgHeader(el);
         this.svgDefs(svgEl);
@@ -456,6 +471,7 @@ export class TextMapperParser {
         this.svgRegions(svgEl);
         this.svgPathLabels(svgEl);
         this.svgLabels(svgEl);
+        this.svgOthers(svgEl);
         return svgEl;
     }
 }


### PR DESCRIPTION
## What it is

This adds a parser for lines that start with "other" and inserts them as elements into a group of their own.  Closes #14.

## Tests

Paste the sample code used for the before and after screenshots:

```
0101 tree "tree"
0102 trees "trees"
0103 forest "forest"
0201 bush "bush"
0202 bushes "bushes"
0203 brushland "brushland"
0301 fir "fir"
0302 firs "firs"
0303 fir-forest "fir-forest"
0401 hill "hill"
0402 mountain "mountain"
0403 mountains "mountains"
0501 fir-hill "fir-hill"
0502 fir-mountain "fir-mountain"
0503 fir-mountains "fir-mountains"
0601 forest-hill "forest-hill"
0602 forest-mountain "forest-mountain"
0603 forest-mountains "forest-mountains"
0604 fields "fields"
0605 desert "desert"
0701 grass "grass"
0702 marsh "marsh"
0703 swamp "swamp"
0704 lake "lake"
0705 shrine "shrine"
0801 keep "keep"
0802 tower "tower"
0803 castle "castle"
0804 law "law"
0805 chaos "chaos"
0806 swamp2 "swamp2"
0901 thorp "thorp"
0902 village "village"
0903 town "town"
0904 large-town "large-town"
0905 city "city"
1001 dust "dust"
1002 light-soil "light-soil"
1003 soil "soil"
1004 dark-soil "dark-soil"
1005 sand "sand"
1006 rock "rock"

1101 light-green "light-green"
1102 green "green"
1103 dark-green "dark-green"
1104 blue-green "blue-green"
1105 water "water"
1106 ocean "ocean"
1201 light-grey "light-grey"
1202 grey "grey"
1203 dark-grey "dark-grey"
1204 poisoned "poisoned"
1205 zone "zone"

# trail example and larger label example
0106 dark-green fir-forest "Deep Forest" 30
0206 green bushes
0306 soil keep "The Keep"
0406 light-soil town "Safe Town"
0005-0506 trail "The Auld Trail" 30%

# larger label example
other <text x="100" y="1170" font-size="40pt">Small Example</text>
```

### Before Screenshot

The image was identical to that in the README.

### After Screenshot

![image](https://github.com/modality/obsidian-text-mapper/assets/89019/b1c2d4db-f10c-4577-ac8f-682ef52b7b35)

### Baseline Screenshot

Paste a screenshot of what the example in README.md looks like. (It's also the example in this document).
